### PR TITLE
Simplify requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 import setuptools
 
-VERSION = '0.4.2'
+VERSION = '0.4.3'
 DESCRIPTION = 'Witnessing multi-partite entanglement.'
 
 with open('./README', encoding = 'utf-8') as file:
@@ -25,8 +25,8 @@ setuptools.setup(
 
     install_requires = [
         'picos >= 2.4',
-        'numpy >= 1.22',
-        'scipy >= 1.8'
+        'numpy',
+        'scipy'
     ],
     packages = [ 'witnessmess' ]
 )

--- a/witnessmess/__init__.py
+++ b/witnessmess/__init__.py
@@ -8,7 +8,7 @@ in multi-partite qubit systems and multi-mode continuous variable Gaussian
 systems.
 '''
 
-version = '0.4.2'
+version = '0.4.3'
 
 # Genuine multi-partite entanglement witness for discrete variable multi-qudit
 # systems inferred from their density matrices.

--- a/witnessmess/_pi.py
+++ b/witnessmess/_pi.py
@@ -5,7 +5,6 @@
 # Shared components.
 
 import picos
-import mosek
 
 # The number $K$ of unique unordered bi-partitions of $N$ elements is given by
 # the Stirling number of the second kind [4] as $K := 2^{N - 1} - 1$.
@@ -67,13 +66,18 @@ def _mosek_check_license ():
     '''
 
     try:
+        import mosek
+    except ImportError as error:
+        return False
+
+    try:
         mosek_env = picos.solvers.get_solver('mosek')._get_environment()
         mosek_env.checkoutlicense(mosek.feature.pton)
         mosek_env.checkinall()
-        return 1
     except mosek.Error as error:
-        return 0
+        return False
 
+    return True
 
 def picos_debug_constraints (problem):
     '''


### PR DESCRIPTION
Removed explicit versions for `numpy` and `scipy` after internal reports of dependency conflicts during installation.